### PR TITLE
Fix Rd

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,7 @@ Authors@R: c(
          role = c("aut"), comment = c(ORCID = "0000-0002-1256-3375")),
   person("Damjan", "Vukcevic", email = "damjan@vukcevic.net",
          role = c("aut"), comment = c(ORCID = "0000-0001-7780-9586")))
-Version: 0.1.0
+Version: 0.1.1
 Depends: R (>= 2.10)
 LazyData: true
 License: GPL-3

--- a/R/adjacency.R
+++ b/R/adjacency.R
@@ -6,13 +6,13 @@
 #' For a `preferences` object with \eqn{N} items, the adjacency
 #' matrix is an \eqn{N} by \eqn{N} matrix, with element \eqn{(i, j)} being the
 #' number of times item \eqn{i} wins over item \eqn{j}. For example, in the
-#' preferences \\{1\\} > \\{3, 4\\} > \\{2\\}, item 1 wins over items 2, 3,
-#' and 4, while items 3 and 4 win over item 2.
+#' preferences \{1\} > \{3, 4\} > \{2\}, item 1 wins over items 2, 3, and 4,
+#' while items 3 and 4 win over item 2.
 #'
 #' If `weights` is specified, the values in the adjacency matrix are the
 #' weighted counts.
 #'
-#' @param object a `\link{preferences}` object, or an object that can be
+#' @param object a [`preferences`][preferences] object, or an object that can be
 #' coerced by `as.preferences`.
 #' @param weights an optional vector of weights for the preferences.
 #' @param ... further arguments passed to/from methods.

--- a/R/aggregate.preferences.R
+++ b/R/aggregate.preferences.R
@@ -10,8 +10,8 @@
 #' object.
 #' @param frequencies A vector of frequencies for preferences that have been
 #' previously aggregated.
-#' @param i indices specifying preferences to extract, as for `\link{[}`.
-#' @param j indices specifying items to extract, as for `\link{[}`.
+#' @param i indices specifying preferences to extract.
+#' @param j indices specifying items to extract.
 #' @param as.aggregated_preferences if `TRUE` create an
 #' `aggregated_preferences` object from the indexed preferences Otherwise
 #' index the underlying matrix of ranks and return in a data frame with the

--- a/R/choices.R
+++ b/R/choices.R
@@ -3,10 +3,10 @@
 #' Convert a set of preferences to a list of choices, alternatives, and
 #' preferences.
 #'
-#' @param preferences a `\link{preferences}` object, or an object that can be
-#' coerced by \code{as.preferences}.
-#' @param names logical: if \code{TRUE} use the object names in the returned
-#' \code{"choices"} object, else use object indices.
+#' @param preferences a [`preferences`][preferences] object, or an object that can be
+#' coerced by `as.preferences`.
+#' @param names logical: if `TRUE` use the object names in the returned
+#' `choices` object, else use object indices.
 #' @return A data frame of class `choices` with elements:
 #' \describe{
 #' \item{choices}{A list where each element represents the items chosen for a

--- a/R/group.preferences.R
+++ b/R/group.preferences.R
@@ -9,14 +9,15 @@
 #' @param x A [`preferences`][preferences] object for `group()`; otherwise a
 #' `grouped_preferences` object.
 #' @param i Indices specifying groups to extract, may be any data type accepted
-#' by `\link{[}`.
-#' @param j Indices specifying items to extract, as for `\link{[}`.
+#' by `[`.
+#' @param j Indices specifying items to extract.
 #' object, otherwise return a matrix/vector.
 #' @param max The maximum number of preferences to format per subject.
 #' @param width The maximum width in number of characters to format the
 #' preferences.
-#' @param ... Additional arguments passed on to `\link{as.preferences}`
-#' by `grouped_preferences`; unused by `format`.
+#' @param ... Additional arguments passed on to
+#' [`as.preferences`][as.preferences] by `grouped_preferences`; unused by
+#' `format`.
 #' @return An object of class `grouped_preferences`, which is a vector of
 #' of group IDs with the following attributes:
 #' \item{preferences}{ The `preferences` object.}

--- a/R/preferences.R
+++ b/R/preferences.R
@@ -73,12 +73,12 @@
 #' integer-valued indices in place of item names, the `item_names` character
 #' vector should be in the correct order.
 #' @param aggregate If `TRUE`, aggregate the preferences via
-#' `\link{aggregate.preferences}` before returning. This returns a
-#' `\link{aggregated_preferences}` object.
+#' [`aggregate.preferences`][aggregate.preferences] before returning. This
+#' returns an [`aggregated_preferences`][aggregate.preferences] object.
 #' @param frequencies An optional integer vector containing the number of
 #' occurences of each preference. If provided, the method will return a
-#' `\link{aggregated_preferences}` object with the corresponding
-#' frequencies.
+#' [`aggregated_preferences`][aggregate.preferences] object with the
+#' corresponding frequencies.
 #' @param verbose If `TRUE`, diagnostic messages will be sent to stdout.
 #' @param ... Unused.
 #'

--- a/R/preflib.R
+++ b/R/preflib.R
@@ -227,7 +227,10 @@ read_preflib <- function(file,
 #' \item{.toi}{Orders with Ties - Incomplete List}
 #' }
 #'
-#' Writing to PrefLib format requires the following additional metadata:
+#' The PrefLib format specification requires some additional metadata. Note
+#' that the additional metadata required for the PrefLib specification is not
+#' necessarily required for the `write_preflib` method; any missing fields
+#' required by the PrefLib format will simply show "NA".
 #' \describe{
 #' \item{TITLE (required)}{
 #'   The title of the data file, for instance the year of the election

--- a/README.Rmd
+++ b/README.Rmd
@@ -24,13 +24,11 @@ The **prefio** R package provides a set of functions which enable users to perfo
 
 ## Installation
 
-<!--
 The package may be installed from CRAN via
 
 ```{r, eval = FALSE}
 install.packages("prefio")
 ```
--->
 
 The development version can be installed via
 ```{r, eval = FALSE}

--- a/README.md
+++ b/README.md
@@ -24,14 +24,11 @@ datasets.
 
 ## Installation
 
-<!--
 The package may be installed from CRAN via
 
-
-```r
+``` r
 install.packages("prefio")
 ```
--->
 
 The development version can be installed via
 
@@ -179,10 +176,10 @@ write_preflib(prefs)
     ## title to be specified. Using `NA`.
 
     ## Warning in write_preflib(prefs): Missing `publication_date`, using today's
-    ## date(2023-03-02).
+    ## date(2023-03-09).
 
     ## Warning in write_preflib(prefs): Missing `modification_date`, using today's
-    ## date(2023-03-02).
+    ## date(2023-03-09).
 
     ## Warning in write_preflib(prefs): Missing `modification_type`: the PrefLib
     ## format requires this to be specified. Using `NA`.
@@ -194,8 +191,8 @@ write_preflib(prefs)
     ## # MODIFICATION TYPE: NA
     ## # RELATES TO: 
     ## # RELATED FILES: 
-    ## # PUBLICATION DATE: 2023-03-02
-    ## # MODIFICATION DATE: 2023-03-02
+    ## # PUBLICATION DATE: 2023-03-09
+    ## # MODIFICATION DATE: 2023-03-09
     ## # NUMBER ALTERNATIVES: 3
     ## # NUMBER VOTERS: 3
     ## # NUMBER UNIQUE ORDERS: 3
@@ -217,9 +214,9 @@ to PrefLib, these warnings must be resolved.
 
 <div id="ref-Bennett2007" class="csl-entry">
 
-Bennett, J., and S. Lanning. 2007. “The Netflix Prize.” In *<span
-class="nocase">Proceedings of the KDD Cup Workshop 2007</span>*, 3–6.
-ACM.
+Bennett, J., and S. Lanning. 2007. “The Netflix Prize.” In
+*<span class="nocase">Proceedings of the KDD Cup Workshop 2007</span>*,
+3–6. ACM.
 
 </div>
 

--- a/man/adjacency.Rd
+++ b/man/adjacency.Rd
@@ -7,7 +7,7 @@
 adjacency(object, weights = NULL, ...)
 }
 \arguments{
-\item{object}{a \verb{\link{preferences}} object, or an object that can be
+\item{object}{a \code{\link{preferences}} object, or an object that can be
 coerced by \code{as.preferences}.}
 
 \item{weights}{an optional vector of weights for the preferences.}
@@ -26,8 +26,8 @@ and losses between pairs of items
 For a \code{preferences} object with \eqn{N} items, the adjacency
 matrix is an \eqn{N} by \eqn{N} matrix, with element \eqn{(i, j)} being the
 number of times item \eqn{i} wins over item \eqn{j}. For example, in the
-preferences \\{1\\} > \\{3, 4\\} > \\{2\\}, item 1 wins over items 2, 3,
-and 4, while items 3 and 4 win over item 2.
+preferences \{1\} > \{3, 4\} > \{2\}, item 1 wins over items 2, 3, and 4,
+while items 3 and 4 win over item 2.
 
 If \code{weights} is specified, the values in the adjacency matrix are the
 weighted counts.

--- a/man/aggregate.preferences.Rd
+++ b/man/aggregate.preferences.Rd
@@ -26,9 +26,9 @@ previously aggregated.}
 
 \item{...}{Additional arguments, currently unused.}
 
-\item{i}{indices specifying preferences to extract, as for \verb{\link{[}}.}
+\item{i}{indices specifying preferences to extract.}
 
-\item{j}{indices specifying items to extract, as for \verb{\link{[}}.}
+\item{j}{indices specifying items to extract.}
 
 \item{as.aggregated_preferences}{if \code{TRUE} create an
 \code{aggregated_preferences} object from the indexed preferences Otherwise

--- a/man/choices.Rd
+++ b/man/choices.Rd
@@ -7,11 +7,11 @@
 choices(preferences, names = FALSE)
 }
 \arguments{
-\item{preferences}{a \verb{\link{preferences}} object, or an object that can be
+\item{preferences}{a \code{\link{preferences}} object, or an object that can be
 coerced by \code{as.preferences}.}
 
 \item{names}{logical: if \code{TRUE} use the object names in the returned
-\code{"choices"} object, else use object indices.}
+\code{choices} object, else use object indices.}
 }
 \value{
 A data frame of class \code{choices} with elements:

--- a/man/group.Rd
+++ b/man/group.Rd
@@ -19,16 +19,17 @@ group(x, ...)
 \item{x}{A \code{\link{preferences}} object for \code{group()}; otherwise a
 \code{grouped_preferences} object.}
 
-\item{...}{Additional arguments passed on to \verb{\link{as.preferences}}
-by \code{grouped_preferences}; unused by \code{format}.}
+\item{...}{Additional arguments passed on to
+\code{\link{as.preferences}} by \code{grouped_preferences}; unused by
+\code{format}.}
 
 \item{index}{A numeric vector or a factor with length equal to the number of
 preferences specifying the subject for each set.}
 
 \item{i}{Indices specifying groups to extract, may be any data type accepted
-by \verb{\link{[}}.}
+by \code{[}.}
 
-\item{j}{Indices specifying items to extract, as for \verb{\link{[}}.
+\item{j}{Indices specifying items to extract.
 object, otherwise return a matrix/vector.}
 
 \item{max}{The maximum number of preferences to format per subject.}

--- a/man/preferences.Rd
+++ b/man/preferences.Rd
@@ -96,12 +96,12 @@ vector should be in the correct order.}
 
 \item{frequencies}{An optional integer vector containing the number of
 occurences of each preference. If provided, the method will return a
-\verb{\link{aggregated_preferences}} object with the corresponding
-frequencies.}
+\code{\link[=aggregate.preferences]{aggregated_preferences}} object with the
+corresponding frequencies.}
 
 \item{aggregate}{If \code{TRUE}, aggregate the preferences via
-\verb{\link{aggregate.preferences}} before returning. This returns a
-\verb{\link{aggregated_preferences}} object.}
+\code{\link{aggregate.preferences}} before returning. This
+returns an \code{\link[=aggregate.preferences]{aggregated_preferences}} object.}
 
 \item{verbose}{If \code{TRUE}, diagnostic messages will be sent to stdout.}
 

--- a/man/write_preflib.Rd
+++ b/man/write_preflib.Rd
@@ -71,7 +71,10 @@ The file types supported are
 \item{.toi}{Orders with Ties - Incomplete List}
 }
 
-Writing to PrefLib format requires the following additional metadata:
+The PrefLib format specification requires some additional metadata. Note
+that the additional metadata required for the PrefLib specification is not
+necessarily required for the \code{write_preflib} method; any missing fields
+required by the PrefLib format will simply show "NA".
 \describe{
 \item{TITLE (required)}{
 The title of the data file, for instance the year of the election


### PR DESCRIPTION
There are a few minor errors in the Rd documentation public on CRAN:
* Sometimes `\link{}` shows in the final pdf, I have reformatted the links in the roxygen in this PR
* The documentation is not explicit what is meant by "required field" in the context of the PrefLib standard. I have added some additional comments around this
* I had double-escaped backslashes in the documentation of `choices`. This was in error and prevented the rendering of curly braces.