### PR TITLE
Allow empty preferences

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,7 @@ Authors@R: c(
          role = c("aut"), comment = c(ORCID = "0000-0002-1256-3375")),
   person("Damjan", "Vukcevic", email = "damjan@vukcevic.net",
          role = c("aut"), comment = c(ORCID = "0000-0001-7780-9586")))
-Version: 0.1.1
+Version: 0.1.3
 Depends: R (>= 2.10)
 LazyData: true
 License: GPL-3

--- a/R/group.preferences.R
+++ b/R/group.preferences.R
@@ -193,7 +193,7 @@ as.data.frame.grouped_preferences <-
 #' @method print grouped_preferences
 #' @export
 print.grouped_preferences <- function(x, max = 2L, width = 20L, ...) {
-  print.default(format(x, max = max, width = width, ...))
+  print.default(format(x, max = max, width = width, ...), quote = FALSE)
 }
 
 #' @rdname group

--- a/R/preferences.R
+++ b/R/preferences.R
@@ -808,7 +808,7 @@ is.na.preferences <- function(x) {
 #' @export
 print.preferences <- function(x, ...) {
   if (length(x) == 0L) {
-    cat("preferences(0)")
+    cat("preferences(0)\n")
   } else {
     print.default(format(x, ...), quote = FALSE)
   }
@@ -834,9 +834,9 @@ format.preferences <- function(x, width = 40L, ...) {
   }
   value <- apply(x, 1L, f, items = attr(x, "item_names"))
   nc <- nchar(value)
-  trunc <- !is.na(nc) & nc > width
-  value[trunc] <- paste(strtrim(value[trunc], width - 4L), "...")
-  value
+  trunc <- !is.na(nc) & nc > (width - 2L)
+  value[trunc] <- paste(strtrim(value[trunc], width - 6L), "...")
+  paste0("[", value, "]")
 }
 
 #' @method rbind preferences

--- a/R/preferences.R
+++ b/R/preferences.R
@@ -379,6 +379,15 @@ long_to_ranking <- function(data,
                             rank,
                             item_names = NULL,
                             verbose = TRUE) {
+  if (dim(data)[1L] == 0L) {
+    return(
+      matrix(
+        ncol = length(item_names),
+        nrow = 0L,
+        dimnames = list(NULL, item_names)
+      )
+    )
+  }
   # Take only required columns
   data <- as.data.frame(data[, c(id, item, rank)])
   colnames(data) <- c("id", "item", "rank")
@@ -746,7 +755,11 @@ as.preferences.matrix <- function(x,
       verbose
     )
   } else if (format == "ranking") {
-    prefs <- t(apply(x, 1L, dplyr::dense_rank))
+    if (all(dim(x) > 0L)) {
+      prefs <- t(apply(x, 1L, dplyr::dense_rank))
+    } else {
+      prefs <- x
+    }
     colnames(prefs) <- item_names
   } else {
     stop("Not implemented.")
@@ -794,7 +807,11 @@ is.na.preferences <- function(x) {
 #' @method print preferences
 #' @export
 print.preferences <- function(x, ...) {
-  print.default(format(x, ...))
+  if (length(x) == 0L) {
+    cat("preferences(0)")
+  } else {
+    print.default(format(x, ...), quote = FALSE)
+  }
 }
 
 #' @method format preferences

--- a/tests/testthat/test-group.R
+++ b/tests/testthat/test-group.R
@@ -43,11 +43,11 @@ test_that("`print.grouped_preferences` formats correctly", {
   expect_output(print(gprefs), "Group X")
   expect_output(print(gprefs), "Group Y")
   expect_output(print(gprefs), "Group Z")
-  expect_output(print(gprefs), '"A > B > C, A > C > B"')
-  expect_output(print(gprefs), '"B > A > C, C > A > B"')
-  expect_output(print(gprefs), '"B > C > A, C > B > A"')
-  expect_output(print(gprefs[, 1]), '"A, A"')
-  expect_output(print(gprefs[, NULL]), '"blank, blank"')
+  expect_output(print(gprefs), "\\[A > B > C\\], \\[A > C > B\\]")
+  expect_output(print(gprefs), "\\[B > A > C\\], \\[C > A > B\\]")
+  expect_output(print(gprefs), "\\[B > C > A\\], \\[C > B > A\\]")
+  expect_output(print(gprefs[, 1]), "\\[A\\], \\[A\\]")
+  expect_output(print(gprefs[, NULL]), "\\[blank\\], \\[blank\\]")
 })
 
 test_that("`as.data.frame` produces one row of grouped_preferences per index", {

--- a/tests/testthat/test-preferences.R
+++ b/tests/testthat/test-preferences.R
@@ -296,6 +296,7 @@ test_that("Formatting of empty preferences object shows `preferences(0)`", {
     format = "ranking"
   )
   expect_output(print(prefs), "preferences\\(0\\)")
+})
 
 e <- character()
 test_that("Constructing preferences from orderings with index and name works", {

--- a/tests/testthat/test-preferences.R
+++ b/tests/testthat/test-preferences.R
@@ -264,3 +264,29 @@ test_that("preferences from long format without id item or rank throws error", {
     preferences(long, format = "long", rank = "rank", id = "id")
   )
 })
+
+test_that("Empty preferences can be created by `preferences`", {
+  expect_success({
+    prefs <- preferences(
+      matrix(ncol = 4, nrow = 0),
+      format = "ranking",
+      item_names = LETTERS[1:4]
+    )
+    expect_true(length(prefs) == 0)
+  })
+  expect_success({
+    prefs <- preferences(
+      matrix(ncol = 3, nrow = 0, dimnames = list(NULL, c("id", "itm", "rnk"))),
+      format = "long",
+      id = "id",
+      item = "itm",
+      rank = "rnk",
+      item_names = LETTERS[1:4]
+    )
+    expect_true(length(prefs) == 0)
+  })
+})
+
+test_that("Formatting of empty preferences object shows `preferences(0)`", {
+
+})

--- a/tests/testthat/test-preferences.R
+++ b/tests/testthat/test-preferences.R
@@ -137,11 +137,14 @@ test_that("Equality and inequality work for `preferences`", {
 
 test_that("`print.preference` formats correctly", {
   prefs <- preferences(rankings, format = "ranking")
-  expect_output(print(prefs), "A > B > C")
-  expect_output(print(prefs), "C > B > A")
-  expect_output(print(prefs), "B > A > C")
-  expect_output(print(prefs[, 1]), '"A" "A" "A"')
-  expect_output(print(prefs[, NULL]), '"blank" "blank" "blank"')
+  expect_output(print(prefs), "\\[A > B > C\\]")
+  expect_output(print(prefs), "\\[C > B > A\\]")
+  expect_output(print(prefs), "\\[B > A > C\\]")
+  expect_output(print(prefs[, 1]), "\\[A\\] \\[A\\] \\[A\\]")
+  expect_output(
+    print(prefs[, NULL]),
+    "\\[blank\\] \\[blank\\] \\[blank\\]"
+  )
 })
 
 test_that("Some valid examples of `preferences` are not `na`", {
@@ -288,5 +291,9 @@ test_that("Empty preferences can be created by `preferences`", {
 })
 
 test_that("Formatting of empty preferences object shows `preferences(0)`", {
-
+  prefs <- preferences(
+    matrix(ncol = 4, nrow = 0, dimnames = list(NULL, LETTERS[1:4])),
+    format = "ranking"
+  )
+  expect_output(print(prefs), "preferences\\(0\\)")
 })


### PR DESCRIPTION
This PR allows preferences to be created from empty matrices with zero rows. We also implement a new print format without quotations, e.g.
```R
preferences(matrix(nrow = 0, ncol = 4), item_names = LETTERS[1:4], format = "ranking")
```
    ## preferences(0)

```R
preferences(matrix(c(1,2,3,4), ncol = 4), item_names = LETTERS[1:4], format = "ranking")
```
    ## [A > B > C > D]