### PR TITLE
Fix loading orderings

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,7 @@ Authors@R: c(
          role = c("aut"), comment = c(ORCID = "0000-0002-1256-3375")),
   person("Damjan", "Vukcevic", email = "damjan@vukcevic.net",
          role = c("aut"), comment = c(ORCID = "0000-0001-7780-9586")))
-Version: 0.1.1
+Version: 0.1.2
 Depends: R (>= 2.10)
 LazyData: true
 License: GPL-3

--- a/R/preferences.R
+++ b/R/preferences.R
@@ -217,7 +217,7 @@ preferences <- function(data,
       verbose = verbose
     )
   } else if (fmt == "ordering") {
-    ranking <- ordering_to_ranking(data, NULL, verbose)
+    ranking <- ordering_to_ranking(data, item_names, verbose)
     prefs <- as.preferences.matrix(ranking,
       format = "ranking",
       ...,

--- a/tests/testthat/test-preferences.R
+++ b/tests/testthat/test-preferences.R
@@ -264,3 +264,20 @@ test_that("preferences from long format without id item or rank throws error", {
     preferences(long, format = "long", rank = "rank", id = "id")
   )
 })
+
+e <- character()
+test_that("Constructing preferences from orderings with index and name works", {
+  prefs <- preferences(
+    as.data.frame(
+      rbind(
+        list("A", "B", e),
+        list(1, 2, e)
+      )
+    ),
+    format = "ordering",
+    item_names = c("A", "B")
+  )
+  # Both rows are evaluated to be equal and then aggregated to one entry with
+  # frequency 2
+  expect_true(aggregate(prefs)$frequencies == 2)
+})


### PR DESCRIPTION
When creating ordering with both index and item names in the same dataframe, the item names would become a union of both. I have resolved this by using the item index where possible.